### PR TITLE
feature: add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,91 @@
+/**
+ * Syntactic units in unist syntax trees are called nodes.
+ */
 export interface Node {
-  type: string;
+  /**
+   * the variant of a node.
+   */
+  type!: string;
+
+  /**
+   * information from the ecosystem.
+   */
   data?: Data;
+
+  /**
+   * location of a node in a source document.
+   * must not be present if a node is generated.
+   */
   position?: Position;
 }
 
+/**
+ * location of a node in a source file.
+ */
 export interface Position {
+  /**
+   * place of the first character of the parsed source region.
+   */
   start: Point;
+
+  /**
+   * place of the first character after the parsed source region.
+   */
   end: Point;
+
+  /**
+   * start column at each index (plus start line) in the source region, for elements that span multiple lines.
+   */
   indent: number;
 }
 
+/**
+ * one place in a source file.
+ */
 export interface Point {
+  /**
+   * line in a source file.
+   * 1-indexed integer.
+   */
   line: number;
+
+  /**
+   * column in a source file.
+   * 1-indexed integer.
+   */
   column: number;
+
+  /**
+   * character in a source file.
+   * 0-indexed integer.
+   */
   offset: number;
 }
 
+/**
+ * information associated by the ecosystem with the node.
+ * space is guaranteed to never be specified by unist or specifications implementing unist.
+ */
 export interface Data {
   [key: string]: unknown;
 }
 
+/**
+ * Nodes containing other nodes.
+ */
 export interface Parent extends Node {
+  /**
+   * list representing the children of a node.
+   */
   children: Node[];
 }
 
+/**
+ * Nodes containing a value
+ */
 export interface Literal extends Node {
+  /**
+   * any value
+   */
   value: unknown;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+export interface Node {
+  type: string;
+  data?: Data;
+  position?: Position;
+}
+
+export interface Position {
+  start: Point;
+  end: Point;
+  indent: number;
+}
+
+export interface Point {
+  line: number;
+  column: number;
+  offset: number;
+}
+
+export interface Data {
+  [key: string]: unknown;
+}
+
+export interface Parent extends Node {
+  children: Node[];
+}
+
+export interface Literal extends Node {
+  value: unknown;
+}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   ],
   "devDependencies": {
     "remark-cli": "^5.0.0",
-    "remark-preset-wooorm": "^4.0.0"
+    "remark-preset-wooorm": "^4.0.0",
+    "typescript": "^3.0.1"
   },
   "scripts": {
-    "format": "remark . -qfo"
+    "format": "remark . -qfo",
+    "validate-types": "tsc index.d.ts"
   },
   "remarkConfig": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "repository": "syntax-tree/unist",
   "bugs": "https://github.com/syntax-tree/unist/issues",
   "author": "Titus Wormer <tituswormer@gmail.com> (wooorm.com)",
-  "types": "./index.d.ts",
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (wooorm.com)",
     "Eugene Sharygin <eush77@gmail.com>",
     "Christian Murphy <christian.murphy.42@gmail.com>"
   ],
+  "types": "./index.d.ts",
   "devDependencies": {
     "remark-cli": "^5.0.0",
     "remark-preset-wooorm": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "unist",
-  "private": true,
   "version": "0.0.0",
   "description": "universal syntax tree",
   "license": "CC-BY-4.0",
@@ -8,9 +7,11 @@
   "repository": "syntax-tree/unist",
   "bugs": "https://github.com/syntax-tree/unist/issues",
   "author": "Titus Wormer <tituswormer@gmail.com> (wooorm.com)",
+  "types": "./index.d.ts",
   "contributors": [
     "Titus Wormer <tituswormer@gmail.com> (wooorm.com)",
-    "Eugene Sharygin <eush77@gmail.com>"
+    "Eugene Sharygin <eush77@gmail.com>",
+    "Christian Murphy <christian.murphy.42@gmail.com>"
   ],
   "devDependencies": {
     "remark-cli": "^5.0.0",


### PR DESCRIPTION
This can be used to provide base types, that downstream standard, like mdast, hast, and nlcst can use, as well as downstream libraries like unified, remark, rehype, and retext.

https://www.typescriptlang.org/docs/handbook/interfaces.html
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html