### PR TITLE
Add `unist-util-ancestor` to list of utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -431,7 +431,7 @@ unist:
 
 ### List of utilities
 
-*   [`unist-util-ancestor`](https://github.com/gorange/unist-util-ancestor)
+*   [`unist-util-ancestor`](https://github.com/gorango/unist-util-ancestor)
     — get the common ancestor of one or more nodes
 *   [`unist-util-assert`](https://github.com/syntax-tree/unist-util-assert)
     — assert nodes

--- a/readme.md
+++ b/readme.md
@@ -431,6 +431,8 @@ unist:
 
 ### List of utilities
 
+*   [`unist-util-ancestor`](https://github.com/gorange/unist-util-ancestor)
+    — get the common ancestor of one or more nodes
 *   [`unist-util-assert`](https://github.com/syntax-tree/unist-util-assert)
     — assert nodes
 *   [`unist-util-filter`](https://github.com/syntax-tree/unist-util-filter)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Adding a small utility to `readme` that helps with finding common ancestors of one or more unist nodes. It has come in handy a few times while working with ast trees so I thought I'd package it up. Here's hoping it might be helpful to someone else too!

P.S. I am open to renaming the package if desired.

<!--do not edit: pr-->
