### PR TITLE
Add `unist-util-replace-all-between` to list of utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -475,6 +475,8 @@ unist:
     — remove nodes from trees
 *   [`unist-util-remove-position`](https://github.com/syntax-tree/unist-util-remove-position)
     — remove positional info from trees
+*   [`unist-util-replace-all-between`](https://github.com/unicorn-utterances/unist-util-replace-all-between)
+    — replace nodes between two nodes or positions
 *   [`unist-util-select`](https://github.com/syntax-tree/unist-util-select)
     — select nodes with CSS-like selectors
 *   [`unist-util-size`](https://github.com/syntax-tree/unist-util-size)
@@ -497,8 +499,6 @@ unist:
     — convert trees to `unist-builder` notation
 *   [`unist-builder-blueprint-cli`](https://github.com/syntax-tree/unist-builder-blueprint-cli)
     — CLI to convert trees to `unist-builder` notation
-*   [`unist-util-replace-all-between`](https://github.com/unicorn-utterances/unist-util-replace-all-between)
-    — replace nodes between two nodes or positions
 
 ## References
 

--- a/readme.md
+++ b/readme.md
@@ -497,6 +497,8 @@ unist:
     — convert trees to `unist-builder` notation
 *   [`unist-builder-blueprint-cli`](https://github.com/syntax-tree/unist-builder-blueprint-cli)
     — CLI to convert trees to `unist-builder` notation
+*   [`unist-util-replace-all-between`](https://github.com/unicorn-utterances/unist-util-replace-all-between)
+    — replace nodes between two nodes or positions
 
 ## References
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I created a package to replace all nodes between two queries in order to build [some `unist`-powered markdown tabs](https://twitter.com/crutchcorn/status/1480149438089678850). This PR adds said package to the list of utilities for `unist`

<!--do not edit: pr-->
