### PR TITLE
Remove `indent` on positions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,6 @@ For example, in JavaScript, a tree can be passed through
 interface Position {
   start: Point
   end: Point
-  indent: [number >= 1]?
 }
 ```
 
@@ -136,9 +135,6 @@ The `end` field of **Position** represents the place of the first character
 after the parsed source region, whether it exists or not.
 The value of the `start` and `end` fields implement the **[Point][dfn-point]**
 interface.
-
-The `indent` field of **Position** represents the start column at each index
-(plus start line) in the source region, for elements that span multiple lines.
 
 If the syntactic unit represented by a node is not present in the source
 *[file][term-file]* at the time of parsing, the node is said to be


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This isn’t used anywhere anymore.
If someone else wants it, it’s better to put into `data`.

Related-to: GH-16.

<!--do not edit: pr-->
