### PR TITLE
Add `unist-plugin-log-tree` to list of plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ The latest released version is [`3.0.0`][release].
 * [Tree traversal](#tree-traversal)
 * [Utilities](#utilities)
   * [List of utilities](#list-of-utilities)
+* [Plugins](#plugins)
+  * [List of plugins](#list-of-plugins)
 * [References](#references)
 * [Contribute](#contribute)
 * [Acknowledgments](#acknowledgments)
@@ -491,6 +493,20 @@ unist:
   — visit nodes after another node
 * [`unist-builder`](https://github.com/syntax-tree/unist-builder)
   — helper for creating trees
+  
+## Plugins
+
+**Plugins** are functions that configure a processor to transform, inspect, or
+modify syntax trees.
+
+**unist plugins** are cross-compatible, which can be used across **remark**,
+**rehype**, and **recma** pipelines because they operate on the underlying
+universal syntax tree specifications.
+
+### List of plugins
+
+* [`unist-plugin-log-tree`](https://github.com/ipikuka/unist-plugin-log-tree)
+  — logs unist syntax trees without mutating for debugging
 
 ## References
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[**`unist-plugin-log-tree`**](https://github.com/ipikuka/unist-plugin-log-tree) is useful when you want to **inspect, debug, or snapshot syntax trees** during a unified processing pipeline.  

**`unist-plugin-log-tree`**  logs and optionally filters unist syntax trees for debugging purposes.

It is a universal syntax tree (unist) plugin for **mdast**, **hast**, **esast**, and other unist-based trees. It does not mutate the tree; it only inspects and logs it for debugging.

Since it is not a util, I've created a **plugins section** in the README.

This change adds **`unist-plugin-log-tree`** into plugin list.

<!--do not edit: pr-->
