### PR TITLE
Add `unist-util-find-between` to list of utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -445,6 +445,8 @@ unist:
   — find nodes between two nodes or positions
 * [`unist-util-find-before`](https://github.com/syntax-tree/unist-util-find-before)
   — find a node before another node
+* [`unist-util-find-between`](https://github.com/ipikuka/unist-util-find-between)
+  — find nodes between two nodes or index
 * [`unist-util-flat-filter`](https://github.com/unicorn-utterances/unist-util-flat-filter)
   — flat map version of `unist-util-filter`
 * [`unist-util-flatmap`](https://gitlab.com/staltz/unist-util-flatmap)


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

[**`unist-util-find-between`**](https://github.com/ipikuka/unist-util-find-between) is a unist utility to find nodes between two nodes or indexes in a parent.

I created it because `unist-util-find-all-between` is not maintained for a long time. See [the issue](https://github.com/mrzmmr/unist-util-find-all-between/issues/25)

This change adds **`unist-util-find-between`** into utility list.

<!--do not edit: pr-->
